### PR TITLE
Feature/refactor increase abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $merge->data(['email' => 'test@test.com']);
 
 $result = $merge->merge(Consolidare\MergeStrategy\MergeStrategyFactory::basic());
 
-$result->retrieve(); // ['id' => 10, 'name' => 'foo', 'email' => 'test@test.com']
+$result->retrieve(new Consolidare\ReturnType\Type\ToArray); // ['id' => 10, 'name' => 'foo', 'email' => 'test@test.com']
 ```
 
 ### Wiki

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ $merge->data(['email' => 'test@test.com']);
 
 $result = $merge->merge(Consolidare\MergeStrategy\MergeStrategyFactory::basic());
 
-$result->retrieve(new Consolidare\ReturnType\Type\ToArray); // ['id' => 10, 'name' => 'foo', 'email' => 'test@test.com']
+$result->retrieve(new Consolidare\ReturnType\Type\ToArray);
+// ['id' => 10, 'name' => 'foo', 'email' => 'test@test.com']
 ```
 
 ### Wiki

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "scripts": {
         "test": [
-            "vendor/bin/phpunit --coverage-html tests/_output --whitelist src tests"
+            "vendor/bin/phpunit --coverage-html='tests/_output' --coverage-text='php://stdout' --colors='auto' --whitelist src tests"
         ]
     }
 }

--- a/src/Merge.php
+++ b/src/Merge.php
@@ -9,28 +9,24 @@ use Consolidare\Record\RecordFactory;
 
 class Merge
 {
-    private $mergeable = [];
+    private $mergeables = [];
 
     public function data($input)
     {
         return $this->mergeable(MergeableFactory::create($input));
     }
 
-    public function mergeable(Mergeable $data)
+    public function mergeable(Mergeable $mergeable)
     {
-        $this->mergeable[] = $data;
+        $this->mergeables[] = $mergeable;
 
         return $this;
     }
 
     public function merge(MergeStrategy $strategy)
     {
-        return array_reduce($this->mergeable, function ($record, $data) use ($strategy) {
-            return RecordFactory::create(
-                $strategy,
-                $record,
-                $data
-            );
+        return array_reduce($this->mergeables, function ($record, $mergeable) use ($strategy) {
+            return RecordFactory::create($strategy, $record)->merge($mergeable);
         });
     }
 }

--- a/src/MergePatterns/Add.php
+++ b/src/MergePatterns/Add.php
@@ -3,20 +3,38 @@
 namespace Consolidare\MergePatterns;
 
 use Consolidare\MergePatterns\Exception\CantAddNonNumericsException;
+use Consolidare\MergePatterns\Exception\FieldMismatchException;
 use Consolidare\MergePatterns\MergePattern;
+use Consolidare\RecordFields\Field;
+use Consolidare\RecordFields\RecordField;
 
 class Add implements MergePattern
 {
-    public function __invoke($left, $right)
+    /**
+     * Takes two fields and returns the sum of both the fields as a new field
+     *
+     * @param  RecordField $left
+     * @param  RecordField $right
+     * @return RecordField
+     * @throws Consolidare\MergePatterns\Exception\CantAddNonNumericsException
+     */
+    public function merge(RecordField $left, RecordField $right)
     {
-        if (!is_numeric($left)) {
+        if ($left->name() !== $right->name()) {
+            throw new FieldMismatchException($left, $right);
+        }
+
+        if (!is_numeric($left->value())) {
             throw new CantAddNonNumericsException($left);
         }
 
-        if (!is_numeric($right)) {
+        if (!is_numeric($right->value())) {
             throw new CantAddNonNumericsException($right);
         }
 
-        return $left + $right;
+        return new Field(
+            $left->name(),
+            ($left->value() + $right->value())
+        );
     }
 }

--- a/src/MergePatterns/Concat.php
+++ b/src/MergePatterns/Concat.php
@@ -2,12 +2,29 @@
 
 namespace Consolidare\MergePatterns;
 
+use Consolidare\MergePatterns\Exception\FieldMismatchException;
 use Consolidare\MergePatterns\MergePattern;
+use Consolidare\RecordFields\Field;
+use Consolidare\RecordFields\RecordField;
 
 class Concat implements MergePattern
 {
-    public function __invoke($left, $right)
+    /**
+     * Takes two fields and returns the two values concatenated together as a new field
+     *
+     * @param  RecordField $left
+     * @param  RecordField $right
+     * @return RecordField
+     */
+    public function merge(RecordField $left, RecordField $right)
     {
-        return sprintf("%s%s", $left, $right);
+        if ($left->name() !== $right->name()) {
+            throw new FieldMismatchException($left, $right);
+        }
+
+        return new Field(
+            $left->name(),
+            sprintf("%s%s", $left->value(), $right->value())
+        );
     }
 }

--- a/src/MergePatterns/Exception/CantAddNonNumericsException.php
+++ b/src/MergePatterns/Exception/CantAddNonNumericsException.php
@@ -3,15 +3,17 @@
 namespace Consolidare\MergePatterns\Exception;
 
 use Consolidare\MergePatterns\Exception\MergePatternException;
+use Consolidare\RecordFields\RecordField;
 
 class CantAddNonNumericsException extends MergePatternException
 {
-    public function __construct($value)
+    public function __construct(RecordField $field)
     {
         parent::__construct(
             sprintf(
-                'You can only add numeric values. %s was not a valid numeric value.',
-                json_encode($value)
+                'You can only add numeric values for field %s. %s was not a valid numeric value.',
+                json_encode($field->name()),
+                json_encode($field->value())
             )
         );
     }

--- a/src/MergePatterns/Exception/FieldMismatchException.php
+++ b/src/MergePatterns/Exception/FieldMismatchException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Consolidare\MergePatterns\Exception;
+
+use Consolidare\MergePatterns\Exception\MergePatternException;
+use Consolidare\RecordFields\RecordField;
+
+class FieldMismatchException extends MergePatternException
+{
+    public function __construct(RecordField $left, RecordField $right)
+    {
+        parent::__construct(
+            sprintf(
+                'The two fields (%s AND %s) you are trying to merge have different names. Something has gone wrong!',
+                json_encode($left->name()),
+                json_encode($right->name())
+            )
+        );
+    }
+}

--- a/src/MergePatterns/Left.php
+++ b/src/MergePatterns/Left.php
@@ -2,12 +2,25 @@
 
 namespace Consolidare\MergePatterns;
 
+use Consolidare\MergePatterns\Exception\FieldMismatchException;
 use Consolidare\MergePatterns\MergePattern;
+use Consolidare\RecordFields\RecordField;
 
 class Left implements MergePattern
 {
-    public function __invoke($left, $right)
+    /**
+     * Takes two fields and returns the left field
+     *
+     * @param  RecordField $left
+     * @param  RecordField $right
+     * @return RecordField
+     */
+    public function merge(RecordField $left, RecordField $right)
     {
+        if ($left->name() !== $right->name()) {
+            throw new FieldMismatchException($left, $right);
+        }
+
         return $left;
     }
 }

--- a/src/MergePatterns/MergePattern.php
+++ b/src/MergePatterns/MergePattern.php
@@ -2,7 +2,16 @@
 
 namespace Consolidare\MergePatterns;
 
+use Consolidare\RecordFields\RecordField;
+
 interface MergePattern
 {
-    public function __invoke($left, $right);
+    /**
+     * Takes two fields and returns a field
+     *
+     * @param  RecordField $left
+     * @param  RecordField $right
+     * @return RecordField
+     */
+    public function merge(RecordField $left, RecordField $right);
 }

--- a/src/MergePatterns/Right.php
+++ b/src/MergePatterns/Right.php
@@ -2,12 +2,25 @@
 
 namespace Consolidare\MergePatterns;
 
+use Consolidare\MergePatterns\Exception\FieldMismatchException;
 use Consolidare\MergePatterns\MergePattern;
+use Consolidare\RecordFields\RecordField;
 
 class Right implements MergePattern
 {
-    public function __invoke($left, $right)
+    /**
+     * Takes two fields and returns the right field
+     *
+     * @param  RecordField $left
+     * @param  RecordField $right
+     * @return RecordField
+     */
+    public function merge(RecordField $left, RecordField $right)
     {
+        if ($left->name() !== $right->name()) {
+            throw new FieldMismatchException($left, $right);
+        }
+
         return $right;
     }
 }

--- a/src/MergeStrategy/MergeStrategy.php
+++ b/src/MergeStrategy/MergeStrategy.php
@@ -2,6 +2,7 @@
 
 namespace Consolidare\MergeStrategy;
 
+use Consolidare\MergePatterns\Exception\FieldMismatchException;
 use Consolidare\MergePatterns\MergePattern;
 use Consolidare\RecordFields\RecordField;
 
@@ -30,14 +31,16 @@ class MergeStrategy
         return $this;
     }
 
-    public function merge($field, $left, $right)
+    public function merge(RecordField $left, RecordField $right)
     {
-        if (isset($this->specific[$field])) {
-            $mergePattern = $this->specific[$field];
-            return $mergePattern($left, $right);
+        if ($left->name() !== $right->name()) {
+            throw new FieldMismatchException($left, $right);
         }
 
-        $mergePattern = $this->default;
-        return $mergePattern($left, $right);
+        if (isset($this->specific[$left->name()])) {
+            return $this->specific[$left->name()]->merge($left, $right);
+        }
+
+        return $this->default->merge($left, $right);
     }
 }

--- a/src/MergeStrategy/MergeStrategyFactory.php
+++ b/src/MergeStrategy/MergeStrategyFactory.php
@@ -4,6 +4,7 @@ namespace Consolidare\MergeStrategy;
 
 use Consolidare\MergePatterns\Right;
 use Consolidare\MergeStrategy\MergeStrategy;
+use Consolidare\RecordFields\Field;
 
 class MergeStrategyFactory
 {

--- a/src/Mergeable/Mergeable.php
+++ b/src/Mergeable/Mergeable.php
@@ -4,5 +4,14 @@ namespace Consolidare\Mergeable;
 
 interface Mergeable
 {
+    /**
+     * Returns an array of the fields. Where the field name is the
+     * key however it contains a field object.
+     *
+     * @return array
+     * [
+     *      'field_1' => new Consolidare\RecordFields\Field('field_1', 'Dave'),
+     * ]
+     */
     public function retrieve();
 }

--- a/src/Mergeable/Type/MergeableArray.php
+++ b/src/Mergeable/Type/MergeableArray.php
@@ -3,6 +3,7 @@
 namespace Consolidare\Mergeable\Type;
 
 use Consolidare\Mergeable\Mergeable;
+use Consolidare\RecordFields\Field;
 
 class MergeableArray implements Mergeable
 {
@@ -10,7 +11,9 @@ class MergeableArray implements Mergeable
 
     public function __construct(array $data)
     {
-        $this->data = $data;
+        array_walk($data, function ($value, $index) {
+            $this->data[$index] = new Field($index, $value);
+        });
     }
 
     public function retrieve()

--- a/src/Mergeable/Type/MergeableJsonObject.php
+++ b/src/Mergeable/Type/MergeableJsonObject.php
@@ -4,6 +4,7 @@ namespace Consolidare\Mergeable\Type;
 
 use Consolidare\Mergeable\Exception\InvalidJsonGivenException;
 use Consolidare\Mergeable\Mergeable;
+use Consolidare\RecordFields\Field;
 
 class MergeableJsonObject implements Mergeable
 {
@@ -17,9 +18,9 @@ class MergeableJsonObject implements Mergeable
             throw new InvalidJsonGivenException($data);
         }
 
-        foreach ($data as $property => $value) {
-            $this->data[$property] = $value;
-        }
+        array_walk($data, function ($value, $index) {
+            $this->data[$index] = new Field($index, $value);
+        });
     }
 
     public function retrieve()

--- a/src/Record/BlankRecord.php
+++ b/src/Record/BlankRecord.php
@@ -2,6 +2,7 @@
 
 namespace Consolidare\Record;
 
+use Consolidare\RecordFields\RecordField;
 use Consolidare\Record\Exception\CantRevertBackFurtherException;
 use Consolidare\Record\Exception\PropertyDoesNotExistException;
 
@@ -11,7 +12,7 @@ class BlankRecord implements Records
     {
     }
 
-    public function property($property)
+    public function field(RecordField $field)
     {
         throw new PropertyDoesNotExistException();
     }

--- a/src/Record/Record.php
+++ b/src/Record/Record.php
@@ -9,6 +9,7 @@ use Consolidare\RecordFields\RecordField;
 use Consolidare\Record\Exception\PropertyDoesNotExistException;
 use Consolidare\Record\Exception\RecordException;
 use Consolidare\Record\Records;
+use Consolidare\ReturnType\ReturnType;
 
 class Record implements Records
 {
@@ -33,8 +34,12 @@ class Record implements Records
         return $this->fields[$field->name()];
     }
 
-    public function retrieve()
+    public function retrieve(ReturnType $returnType = NULL)
     {
+        if ($returnType) {
+            return $returnType($this);
+        }
+
         return $this->fields;
     }
 

--- a/src/Record/RecordFactory.php
+++ b/src/Record/RecordFactory.php
@@ -2,18 +2,18 @@
 
 namespace Consolidare\Record;
 
-use Consolidare\Mergeable\Mergeable;
 use Consolidare\MergeStrategy\MergeStrategy;
+use Consolidare\Record\BlankRecord;
 use Consolidare\Record\Record;
 use Consolidare\Record\Records;
 
 class RecordFactory
 {
-    public static function create(MergeStrategy $strategy, Records $previousRecord = NULL, Mergeable $mergeable)
+    public static function create(MergeStrategy $strategy, Records $previousRecord = NULL)
     {
         if (!$previousRecord) {
             $previousRecord = new BlankRecord();
         }
-        return new Record($strategy, $previousRecord, $mergeable);
+        return new Record($strategy, $previousRecord);
     }
 }

--- a/src/Record/Records.php
+++ b/src/Record/Records.php
@@ -2,9 +2,11 @@
 
 namespace Consolidare\Record;
 
+use Consolidare\RecordFields\RecordField;
+
 interface Records
 {
-    public function property($property);
+    public function field(RecordField $field);
     public function retrieve();
     public function revert();
 }

--- a/src/RecordFields/Field.php
+++ b/src/RecordFields/Field.php
@@ -7,14 +7,21 @@ use Consolidare\RecordFields\RecordField;
 class Field implements RecordField
 {
     private $name = '';
+    private $value = '';
 
-    public function __construct($name)
+    public function __construct($name, $value = NULL)
     {
         $this->name = $name;
+        $this->value = $value;
     }
 
     public function name()
     {
         return $this->name;
+    }
+
+    public function value()
+    {
+        return $this->value;
     }
 }

--- a/src/RecordFields/RecordField.php
+++ b/src/RecordFields/RecordField.php
@@ -5,4 +5,6 @@ namespace Consolidare\RecordFields;
 interface RecordField
 {
     public function name();
+
+    public function value();
 }

--- a/src/ReturnType/ReturnType.php
+++ b/src/ReturnType/ReturnType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Consolidare\ReturnType;
+
+use Consolidare\Record\Records;
+
+interface ReturnType {
+    public function __invoke(Records $record);
+}

--- a/src/ReturnType/Type/ToArray.php
+++ b/src/ReturnType/Type/ToArray.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Consolidare\ReturnType\Type;
+
+use Consolidare\Record\Records;
+use Consolidare\ReturnType\ReturnType;
+
+class ToArray implements ReturnType
+{
+    public function __invoke(Records $record)
+    {
+        return array_map(function($field) {
+            return $field->value();
+        }, $record->retrieve());
+    }
+}

--- a/src/ReturnType/Type/ToJson.php
+++ b/src/ReturnType/Type/ToJson.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Consolidare\ReturnType\Type;
+
+use Consolidare\Record\Records;
+use Consolidare\ReturnType\ReturnType;
+
+class ToJson implements ReturnType
+{
+    public function __invoke(Records $record)
+    {
+        return json_encode(array_map(function($field) {
+            return $field->value();
+        }, $record->retrieve()));
+    }
+}

--- a/tests/Mergable/Type/MergeableArrayTest.php
+++ b/tests/Mergable/Type/MergeableArrayTest.php
@@ -2,6 +2,7 @@
 
 use Consolidare\Mergeable\Mergeable;
 use Consolidare\Mergeable\Type\MergeableArray;
+use Consolidare\RecordFields\RecordField;
 use PHPUnit\Framework\TestCase;
 
 class MergeableArrayTest extends TestCase
@@ -23,9 +24,29 @@ class MergeableArrayTest extends TestCase
     public function testDataCanBeRetrieved()
     {
         $mergeableArray = new MergeableArray(['foo' => 'foo', 'bar' => 'bar']);
-        $this->assertEquals(
-            ['foo' => 'foo', 'bar' => 'bar'],
-            $mergeableArray->retrieve()
-        );
+        $this->assertEquals(2, count($mergeableArray->retrieve()));
+    }
+
+    public function testCorrectKeysExsist()
+    {
+        $mergeableArray = new MergeableArray(['foo' => 'foo', 'bar' => 'bar']);
+        $this->assertTrue(array_key_exists('foo', $mergeableArray->retrieve()));
+        $this->assertTrue(array_key_exists('bar', $mergeableArray->retrieve()));
+    }
+
+    public function testValueCanBeRetrieved()
+    {
+        $mergeableArray = new MergeableArray(['foo' => 'foo', 'bar' => 'bar']);
+        $fields = $mergeableArray->retrieve();
+        $this->assertEquals('foo', $fields['foo']->value());
+        $this->assertEquals('bar', $fields['bar']->value());
+    }
+
+    public function testFieldsHaveBeenCreatedCorrectly()
+    {
+        $mergeableArray = new MergeableArray(['foo' => 'foo', 'bar' => 'bar']);
+        $fields = $mergeableArray->retrieve();
+        $this->assertTrue($fields['foo'] instanceof RecordField);
+        $this->assertTrue($fields['bar'] instanceof RecordField);
     }
 }

--- a/tests/Mergable/Type/MergeableJsonObjectTest.php
+++ b/tests/Mergable/Type/MergeableJsonObjectTest.php
@@ -3,6 +3,7 @@
 use Consolidare\Mergeable\Exception\InvalidJsonGivenException;
 use Consolidare\Mergeable\Mergeable;
 use Consolidare\Mergeable\Type\MergeableJsonObject;
+use Consolidare\RecordFields\RecordField;
 use PHPUnit\Framework\TestCase;
 
 class MergeableJsonObjectTest extends TestCase
@@ -24,10 +25,30 @@ class MergeableJsonObjectTest extends TestCase
     public function testDataCanBeRetrieved()
     {
         $mergeableJsonObject = new MergeableJsonObject('{"foo": "foo", "bar": "bar"}');
-        $this->assertEquals(
-            ['foo' => 'foo', 'bar' => 'bar'],
-            $mergeableJsonObject->retrieve()
-        );
+        $this->assertEquals(2, count($mergeableJsonObject->retrieve()));
+    }
+
+    public function testCorrectKeysExsist()
+    {
+        $mergeableJsonObject = new MergeableJsonObject('{"foo": "foo", "bar": "bar"}');
+        $this->assertTrue(array_key_exists('foo', $mergeableJsonObject->retrieve()));
+        $this->assertTrue(array_key_exists('bar', $mergeableJsonObject->retrieve()));
+    }
+
+    public function testValueCanBeRetrieved()
+    {
+        $mergeableJsonObject = new MergeableJsonObject('{"foo": "foo", "bar": "bar"}');
+        $fields = $mergeableJsonObject->retrieve();
+        $this->assertEquals('foo', $fields['foo']->value());
+        $this->assertEquals('bar', $fields['bar']->value());
+    }
+
+    public function testFieldsHaveBeenCreatedCorrectly()
+    {
+        $mergeableJsonObject = new MergeableJsonObject('{"foo": "foo", "bar": "bar"}');
+        $fields = $mergeableJsonObject->retrieve();
+        $this->assertTrue($fields['foo'] instanceof RecordField);
+        $this->assertTrue($fields['bar'] instanceof RecordField);
     }
 
     public function testItThrowsAnExceptionWithInvalidJson()

--- a/tests/MergePatterns/AddTest.php
+++ b/tests/MergePatterns/AddTest.php
@@ -2,8 +2,12 @@
 
 use Consolidare\MergePatterns\Add;
 use Consolidare\MergePatterns\Exception\CantAddNonNumericsException;
+use Consolidare\MergePatterns\Exception\FieldMismatchException;
 use Consolidare\MergePatterns\MergePattern;
+use Consolidare\RecordFields\Field;
+use Consolidare\RecordFields\RecordField;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophet;
 
 class AddTest extends TestCase
 {
@@ -17,34 +21,100 @@ class AddTest extends TestCase
 
     public function testItAdds()
     {
+        $prophet = new Prophet;
+
+        $left = $prophet->prophesize(RecordField::class);
+        $left->name()->willReturn('sum');
+        $left->value()->willReturn(4);
+        $right = $prophet->prophesize(RecordField::class);
+        $right->name()->willReturn('sum');
+        $right->value()->willReturn(6);
+
         $add = new Add;
-        $this->assertEquals(10, $add(4, 6));
+        $newField = $add->merge($left->reveal(), $right->reveal());
+
+        $this->assertEquals('sum', $newField->name());
+        $this->assertEquals(10, $newField->value());
+    }
+
+    public function testNewFieldHasSameName()
+    {
+        $prophet = new Prophet;
+
+        $left = $prophet->prophesize(RecordField::class);
+        $left->name()->willReturn('sum');
+        $left->value()->willReturn(4);
+        $right = $prophet->prophesize(RecordField::class);
+        $right->name()->willReturn('sum');
+        $right->value()->willReturn(6);
+
+        $add = new Add;
+        $newField = $add->merge($left->reveal(), $right->reveal());
+
+        $this->assertEquals('sum', $newField->name());
+    }
+
+    public function testItThowsExceptionIfNamesDoNotMatch()
+    {
+        $this->setExpectedException(FieldMismatchException::class);
+
+        $prophet = new Prophet;
+
+        $left = $prophet->prophesize(RecordField::class);
+        $left->name()->willReturn('a');
+        $right = $prophet->prophesize(RecordField::class);
+        $right->name()->willReturn('b');
+
+        $add = new Add;
+        $newField = $add->merge($left->reveal(), $right->reveal());
     }
 
     public function testItAddsNumericStrings()
     {
-        $add = new Add;
-        $this->assertEquals(26, $add('7', "19"));
-    }
+        $prophet = new Prophet;
 
-    public function testItCantAddStrings()
-    {
-        $this->setExpectedException(CantAddNonNumericsException::class);
+        $left = $prophet->prophesize(RecordField::class);
+        $left->name()->willReturn('sum');
+        $left->value()->willReturn(7);
+        $right = $prophet->prophesize(RecordField::class);
+        $right->name()->willReturn('sum');
+        $right->value()->willReturn(19);
+
         $add = new Add;
-        $add('phil', "jess");
+        $newField = $add->merge($left->reveal(), $right->reveal());
+
+        $this->assertEquals('sum', $newField->name());
+        $this->assertEquals(26, $newField->value());
     }
 
     public function testItCantAddWithLeftStringValue()
     {
         $this->setExpectedException(CantAddNonNumericsException::class);
+
+        $prophet = new Prophet;
+        $left = $prophet->prophesize(RecordField::class);
+        $left->value()->willReturn('phil');
+        $left->name()->willReturn('sum');
+        $right = $prophet->prophesize(RecordField::class);
+        $right->name()->willReturn('sum');
+
         $add = new Add;
-        $add('phil', 10);
+        $add->merge($left->reveal(), $right->reveal());
     }
 
     public function testItCantAddWithRightStringValue()
     {
         $this->setExpectedException(CantAddNonNumericsException::class);
+
+        $prophet = new Prophet;
+        $left = $prophet->prophesize(RecordField::class);
+        $left->name()->willReturn('sum');
+        $left->value()->willReturn(10);
+        $right = $prophet->prophesize(RecordField::class);
+        $right->value()->willReturn('jess');
+        $right->name()->willReturn('sum');
+
         $add = new Add;
-        $add(10, 'jess');
+        $add->merge($left->reveal(), $right->reveal());
     }
 }

--- a/tests/MergePatterns/ConcatTest.php
+++ b/tests/MergePatterns/ConcatTest.php
@@ -1,8 +1,11 @@
 <?php
 
 use Consolidare\MergePatterns\Concat;
+use Consolidare\MergePatterns\Exception\FieldMismatchException;
 use Consolidare\MergePatterns\MergePattern;
+use Consolidare\RecordFields\RecordField;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophet;
 
 class ConcatTest extends TestCase
 {
@@ -16,19 +19,81 @@ class ConcatTest extends TestCase
 
     public function testItConcatsStrings()
     {
+        $prophet = new Prophet;
+
+        $left = $prophet->prophesize(RecordField::class);
+        $left->name()->willReturn('concat');
+        $left->value()->willReturn('Foo');
+        $right = $prophet->prophesize(RecordField::class);
+        $right->name()->willReturn('concat');
+        $right->value()->willReturn('Bar');
+
         $concat = new Concat;
-        $this->assertEquals("FooBar", $concat("Foo", "Bar"));
+        $newField = $concat->merge($left->reveal(), $right->reveal());
+        $this->assertEquals("FooBar", $newField->value());
+    }
+
+    public function testNewFieldHasSameName()
+    {
+        $prophet = new Prophet;
+
+        $left = $prophet->prophesize(RecordField::class);
+        $left->name()->willReturn('concat');
+        $left->value()->willReturn('Foo');
+        $right = $prophet->prophesize(RecordField::class);
+        $right->name()->willReturn('concat');
+        $right->value()->willReturn('Bar');
+
+        $concat = new Concat;
+        $newField = $concat->merge($left->reveal(), $right->reveal());
+
+        $this->assertEquals('concat', $newField->name());
+    }
+
+    public function testItThowsExceptionIfNamesDoNotMatch()
+    {
+        $this->setExpectedException(FieldMismatchException::class);
+
+        $prophet = new Prophet;
+
+        $left = $prophet->prophesize(RecordField::class);
+        $left->name()->willReturn('a');
+        $right = $prophet->prophesize(RecordField::class);
+        $right->name()->willReturn('b');
+
+        $concat = new Concat;
+        $newField = $concat->merge($left->reveal(), $right->reveal());
     }
 
     public function testItConcatsIntegers()
     {
+        $prophet = new Prophet;
+
+        $left = $prophet->prophesize(RecordField::class);
+        $left->name()->willReturn('concat');
+        $left->value()->willReturn(10);
+        $right = $prophet->prophesize(RecordField::class);
+        $right->name()->willReturn('concat');
+        $right->value()->willReturn(20);
+
         $concat = new Concat;
-        $this->assertEquals("1020", $concat(10, 20));
+        $newField = $concat->merge($left->reveal(), $right->reveal());
+        $this->assertEquals("1020", $newField->value());
     }
 
     public function testItConcatsFloats()
     {
+        $prophet = new Prophet;
+
+        $left = $prophet->prophesize(RecordField::class);
+        $left->name()->willReturn('concat');
+        $left->value()->willReturn(10.5);
+        $right = $prophet->prophesize(RecordField::class);
+        $right->name()->willReturn('concat');
+        $right->value()->willReturn(20.3);
+
         $concat = new Concat;
-        $this->assertEquals("10.520.3", $concat(10.5, 20.3));
+        $newField = $concat->merge($left->reveal(), $right->reveal());
+        $this->assertEquals("10.520.3", $newField->value());
     }
 }

--- a/tests/MergePatterns/LeftTest.php
+++ b/tests/MergePatterns/LeftTest.php
@@ -1,8 +1,11 @@
 <?php
 
+use Consolidare\MergePatterns\Exception\FieldMismatchException;
 use Consolidare\MergePatterns\Left;
 use Consolidare\MergePatterns\MergePattern;
+use Consolidare\RecordFields\RecordField;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophet;
 
 class LeftTest extends TestCase
 {
@@ -16,7 +19,51 @@ class LeftTest extends TestCase
 
     public function testItReturnsLeftValue()
     {
-        $left = new Left;
-        $this->assertEquals("Foo", $left("Foo", "Bar"));
+        $prophet = new Prophet;
+
+        $left = $prophet->prophesize(RecordField::class);
+        $left->name()->willReturn('left');
+        $left->value()->willReturn('Foo');
+        $right = $prophet->prophesize(RecordField::class);
+        $right->name()->willReturn('left');
+        $right->value()->willReturn('Bar');
+
+        $leftPattern = new Left;
+        $field = $leftPattern->merge($left->reveal(), $right->reveal());
+
+        $this->assertEquals($left->reveal(), $field);
+        $this->assertEquals('Foo', $field->value());
+    }
+
+    public function testNewFieldHasSameName()
+    {
+        $prophet = new Prophet;
+
+        $left = $prophet->prophesize(RecordField::class);
+        $left->name()->willReturn('left');
+        $left->value()->willReturn('Foo');
+        $right = $prophet->prophesize(RecordField::class);
+        $right->name()->willReturn('left');
+        $right->value()->willReturn('Bar');
+
+        $leftPattern = new Left;
+        $field = $leftPattern->merge($left->reveal(), $right->reveal());
+
+        $this->assertEquals('left', $field->name());
+    }
+
+    public function testItThowsExceptionIfNamesDoNotMatch()
+    {
+        $this->setExpectedException(FieldMismatchException::class);
+
+        $prophet = new Prophet;
+
+        $left = $prophet->prophesize(RecordField::class);
+        $left->name()->willReturn('a');
+        $right = $prophet->prophesize(RecordField::class);
+        $right->name()->willReturn('b');
+
+        $leftPattern = new Left;
+        $field = $leftPattern->merge($left->reveal(), $right->reveal());
     }
 }

--- a/tests/MergePatterns/RightTest.php
+++ b/tests/MergePatterns/RightTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Consolidare\MergePatterns\Right;
+use Consolidare\MergePatterns\Exception\FieldMismatchException;
 use Consolidare\MergePatterns\MergePattern;
+use Consolidare\MergePatterns\Right;
+use Consolidare\RecordFields\RecordField;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophet;
 
 class RightTest extends TestCase
 {
@@ -16,7 +19,51 @@ class RightTest extends TestCase
 
     public function testItReturnsRightValue()
     {
-        $right = new Right;
-        $this->assertEquals("Bar", $right("Foo", "Bar"));
+        $prophet = new Prophet;
+
+        $left = $prophet->prophesize(RecordField::class);
+        $left->name()->willReturn('right');
+        $left->value()->willReturn('Foo');
+        $right = $prophet->prophesize(RecordField::class);
+        $right->name()->willReturn('right');
+        $right->value()->willReturn('Bar');
+
+        $rightPattern = new Right;
+        $field = $rightPattern->merge($left->reveal(), $right->reveal());
+
+        $this->assertEquals($right->reveal(), $field);
+        $this->assertEquals('Bar', $field->value());
+    }
+
+    public function testNewFieldHasSameName()
+    {
+        $prophet = new Prophet;
+
+        $left = $prophet->prophesize(RecordField::class);
+        $left->name()->willReturn('right');
+        $left->value()->willReturn('Foo');
+        $right = $prophet->prophesize(RecordField::class);
+        $right->name()->willReturn('right');
+        $right->value()->willReturn('Bar');
+
+        $rightPattern = new Right;
+        $field = $rightPattern->merge($left->reveal(), $right->reveal());
+
+        $this->assertEquals('right', $field->name());
+    }
+
+    public function testItThowsExceptionIfNamesDoNotMatch()
+    {
+        $this->setExpectedException(FieldMismatchException::class);
+
+        $prophet = new Prophet;
+
+        $left = $prophet->prophesize(RecordField::class);
+        $left->name()->willReturn('a');
+        $right = $prophet->prophesize(RecordField::class);
+        $right->name()->willReturn('b');
+
+        $rightPattern = new Right;
+        $field = $rightPattern->merge($left->reveal(), $right->reveal());
     }
 }

--- a/tests/MergeTest.php
+++ b/tests/MergeTest.php
@@ -3,6 +3,7 @@
 use Consolidare\Merge;
 use Consolidare\MergeStrategy\MergeStrategy;
 use Consolidare\MergeStrategy\MergeStrategyFactory;
+use Consolidare\RecordFields\RecordField;
 use Consolidare\Record\Record;
 use PHPUnit\Framework\TestCase;
 
@@ -37,7 +38,17 @@ class MergeTest extends TestCase
         $merge->data(['name' => 'foo', 'email' => 'foo']);
         $record = $merge->merge(MergeStrategyFactory::basic());
 
-        $this->assertEquals(['name' => 'foo', 'email' => 'foo'], $record->retrieve());
+        $this->assertEquals(2, count($record->retrieve()));
+
+        $record = $record->retrieve();
+
+        $this->assertEquals('foo', $record['name']->value());
+        $this->assertTrue($record['name'] instanceof RecordField);
+        $this->assertEquals('name', $record['name']->name());
+
+        $this->assertEquals('foo', $record['email']->value());
+        $this->assertTrue($record['email'] instanceof RecordField);
+        $this->assertEquals('email', $record['email']->name());
     }
 
     public function testItMergesWhenGivenAMultipleValuesFromArray()
@@ -48,7 +59,17 @@ class MergeTest extends TestCase
               ->data(['name' => 'baz', 'email' => 'baz']);
         $record = $merge->merge(MergeStrategyFactory::basic());
 
-        $this->assertEquals(['name' => 'baz', 'email' => 'baz'], $record->retrieve());
+        $this->assertEquals(2, count($record->retrieve()));
+
+        $record = $record->retrieve();
+
+        $this->assertEquals('baz', $record['name']->value());
+        $this->assertTrue($record['name'] instanceof RecordField);
+        $this->assertEquals('name', $record['name']->name());
+
+        $this->assertEquals('baz', $record['email']->value());
+        $this->assertTrue($record['email'] instanceof RecordField);
+        $this->assertEquals('email', $record['email']->name());
     }
 
     public function testItKeepsAllValuesWhenGivenAMultipleValuesFromArray()
@@ -59,9 +80,26 @@ class MergeTest extends TestCase
               ->data(['name' => 'baz', 'email' => 'baz', 'address' => 'baz']);
         $record = $merge->merge(MergeStrategyFactory::basic());
 
-        $this->assertEquals(['name' => 'baz', 'email' => 'baz', 'surname' => 'foo', 'address' => 'baz'], $record->retrieve());
-    }
+        $this->assertEquals(4, count($record->retrieve()));
 
+        $record = $record->retrieve();
+
+        $this->assertEquals('baz', $record['name']->value());
+        $this->assertTrue($record['name'] instanceof RecordField);
+        $this->assertEquals('name', $record['name']->name());
+
+        $this->assertEquals('baz', $record['email']->value());
+        $this->assertTrue($record['email'] instanceof RecordField);
+        $this->assertEquals('email', $record['email']->name());
+
+        $this->assertEquals('foo', $record['surname']->value());
+        $this->assertTrue($record['surname'] instanceof RecordField);
+        $this->assertEquals('surname', $record['surname']->name());
+
+        $this->assertEquals('baz', $record['address']->value());
+        $this->assertTrue($record['address'] instanceof RecordField);
+        $this->assertEquals('address', $record['address']->name());
+    }
 
     public function testItMergesWhenGivenAMultipleValuesFromMultipleDataTypes()
     {
@@ -70,9 +108,22 @@ class MergeTest extends TestCase
               ->data('{"name": "bar", "address": "bar"}');
         $record = $merge->merge(MergeStrategyFactory::basic());
 
-        $this->assertEquals(['name' => 'bar', 'email' => 'foo', 'address' => 'bar'], $record->retrieve());
-    }
+        $this->assertEquals(3, count($record->retrieve()));
 
+        $record = $record->retrieve();
+
+        $this->assertEquals('bar', $record['name']->value());
+        $this->assertTrue($record['name'] instanceof RecordField);
+        $this->assertEquals('name', $record['name']->name());
+
+        $this->assertEquals('foo', $record['email']->value());
+        $this->assertTrue($record['email'] instanceof RecordField);
+        $this->assertEquals('email', $record['email']->name());
+
+        $this->assertEquals('bar', $record['address']->value());
+        $this->assertTrue($record['address'] instanceof RecordField);
+        $this->assertEquals('address', $record['address']->name());
+    }
 
     public function testItKeepsRevertsAMerge()
     {
@@ -83,6 +134,20 @@ class MergeTest extends TestCase
         $record = $merge->merge(MergeStrategyFactory::basic());
         $record = $record->revert();
 
-        $this->assertEquals(['name' => 'bar', 'email' => 'foo', 'surname' => 'foo'], $record->retrieve());
+        $this->assertEquals(3, count($record->retrieve()));
+
+        $record = $record->retrieve();
+
+        $this->assertEquals('bar', $record['name']->value());
+        $this->assertTrue($record['name'] instanceof RecordField);
+        $this->assertEquals('name', $record['name']->name());
+
+        $this->assertEquals('foo', $record['email']->value());
+        $this->assertTrue($record['email'] instanceof RecordField);
+        $this->assertEquals('email', $record['email']->name());
+
+        $this->assertEquals('foo', $record['surname']->value());
+        $this->assertTrue($record['surname'] instanceof RecordField);
+        $this->assertEquals('surname', $record['surname']->name());
     }
 }

--- a/tests/MergeTest.php
+++ b/tests/MergeTest.php
@@ -5,6 +5,7 @@ use Consolidare\MergeStrategy\MergeStrategy;
 use Consolidare\MergeStrategy\MergeStrategyFactory;
 use Consolidare\RecordFields\RecordField;
 use Consolidare\Record\Record;
+use Consolidare\ReturnType\Type\ToArray;
 use PHPUnit\Framework\TestCase;
 
 class MergeTest extends TestCase
@@ -149,5 +150,25 @@ class MergeTest extends TestCase
         $this->assertEquals('foo', $record['surname']->value());
         $this->assertTrue($record['surname'] instanceof RecordField);
         $this->assertEquals('surname', $record['surname']->name());
+    }
+
+    public function testItChangesTheReturnTypeWhenAsked()
+    {
+        $merge = new Merge([]);
+        $merge->data(['name' => 'foo', 'email' => 'foo', 'surname' => 'foo'])
+              ->data(['name' => 'bar'])
+              ->data(['email' => 'baz', 'address' => 'baz']);
+        $record = $merge->merge(MergeStrategyFactory::basic());
+
+        $this->assertEquals(4, count($record->retrieve()));
+
+        $array = $record->retrieve(new ToArray);
+
+        $this->assertEquals([
+            'name' => 'bar',
+            'email' => 'baz',
+            'surname' => 'foo',
+            'address' => 'baz',
+        ], $array);
     }
 }

--- a/tests/Record/BlankRecordTest.php
+++ b/tests/Record/BlankRecordTest.php
@@ -1,10 +1,12 @@
 <?php
 
+use Consolidare\RecordFields\RecordField;
 use Consolidare\Record\BlankRecord;
 use Consolidare\Record\Exception\CantRevertBackFurtherException;
 use Consolidare\Record\Exception\PropertyDoesNotExistException;
 use Consolidare\Record\Records;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophet;
 
 class BlankRecordTest extends TestCase
 {
@@ -27,7 +29,12 @@ class BlankRecordTest extends TestCase
     public function testPropertyThrowsException()
     {
         $this->setExpectedException(PropertyDoesNotExistException::class);
-        (new BlankRecord)->property('foo');
+
+        $prophet = new Prophet;
+        $record = $prophet->prophesize(RecordField::class);
+        $record->name()->willReturn('foo');
+
+        (new BlankRecord)->field($record->reveal());
     }
 
     public function testRevertThrowsException()

--- a/tests/Record/RecordTest.php
+++ b/tests/Record/RecordTest.php
@@ -1,11 +1,14 @@
 <?php
 
-use Consolidare\Mergeable\Mergeable;
 use Consolidare\MergeStrategy\MergeStrategy;
+use Consolidare\Mergeable\Mergeable;
+use Consolidare\RecordFields\RecordField;
 use Consolidare\Record\Exception\PropertyDoesNotExistException;
+use Consolidare\Record\Exception\RecordException;
 use Consolidare\Record\Record;
 use Consolidare\Record\Records;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\Prophet;
 
 class RecordTest extends TestCase
@@ -13,16 +16,15 @@ class RecordTest extends TestCase
     public function testItConstructs()
     {
         $prophet = new Prophet;
+
         $mergeStrategy = $prophet->prophesize(MergeStrategy::class);
+
         $record = $prophet->prophesize(Records::class);
-        $mergeable = $prophet->prophesize(Mergeable::class);
-        $mergeable->retrieve()->willReturn([]);
 
         $this->assertEquals(
             get_class(new Record(
                 $mergeStrategy->reveal(),
-                $record->reveal(),
-                $mergeable->reveal()
+                $record->reveal()
             )),
             Record::class
         );
@@ -31,31 +33,30 @@ class RecordTest extends TestCase
     public function testItImplementsRecordsInterface()
     {
         $prophet = new Prophet;
+
         $mergeStrategy = $prophet->prophesize(MergeStrategy::class);
+
         $record = $prophet->prophesize(Records::class);
-        $mergeable = $prophet->prophesize(Mergeable::class);
-        $mergeable->retrieve()->willReturn([]);
 
         $this->assertTrue(in_array(
             Records::class,
             class_implements(new Record(
                 $mergeStrategy->reveal(),
-                $record->reveal(),
-                $mergeable->reveal()
+                $record->reveal()
             ))
         ));
     }
 
-    public function testItsPropertiesCanBeRetrieved()
+    public function testItsUnMergedPropertiesCanBeRetrieved()
     {
         $prophet = new Prophet;
+
         $mergeStrategy = $prophet->prophesize(MergeStrategy::class);
+
         $record = $prophet->prophesize(Records::class);
         $record->retrieve()->willReturn([]);
-        $mergeable = $prophet->prophesize(Mergeable::class);
-        $mergeable->retrieve()->willReturn([]);
 
-        $record = new Record($mergeStrategy->reveal(), $record->reveal(), $mergeable->reveal());
+        $record = new Record($mergeStrategy->reveal(), $record->reveal());
 
         $this->assertEquals(
             [],
@@ -63,133 +64,239 @@ class RecordTest extends TestCase
         );
     }
 
-    public function testItsPropertiesCanBeRetrievedWithDataInRecord()
+    public function testItsUnMergedPropertiesCanBeRetrievedWithDataInRecord()
     {
         $prophet = new Prophet;
+
         $mergeStrategy = $prophet->prophesize(MergeStrategy::class);
+
         $record = $prophet->prophesize(Records::class);
-        $record->retrieve()->willReturn(['foo']);
+        $record->retrieve()->willReturn(['foo' => 'bar']);
+
+        $record = new Record($mergeStrategy->reveal(), $record->reveal());
+
+        $this->assertEquals(
+            ['foo' => 'bar'],
+            $record->retrieve()
+        );
+    }
+
+    public function testItsMergedPropertiesCanBeRetrievedWithDataInRecordAndBlankMerge()
+    {
+        $prophet = new Prophet;
+
+        $mergeStrategy = $prophet->prophesize(MergeStrategy::class);
+
+        $record = $prophet->prophesize(Records::class);
+        $record->retrieve()->willReturn(['foo' => 'bar']);
+
         $mergeable = $prophet->prophesize(Mergeable::class);
         $mergeable->retrieve()->willReturn([]);
 
-        $record = new Record($mergeStrategy->reveal(), $record->reveal(), $mergeable->reveal());
+        $record = new Record($mergeStrategy->reveal(), $record->reveal());
+        $record->merge($mergeable->reveal());
 
         $this->assertEquals(
-            ['foo'],
+            ['foo' => 'bar'],
             $record->retrieve()
         );
     }
 
-    public function testItsPropertiesCanBeRetrievedWithDataInMergeable()
+    public function testItsPropertiesCanBeRetrievedWithDataInRecordAndMergeable()
     {
         $prophet = new Prophet;
-        $mergeStrategy = $prophet->prophesize(MergeStrategy::class);
-        $record = $prophet->prophesize(Records::class);
-        $record->retrieve()->willReturn([]);
-        $record->property(0)->willThrow(PropertyDoesNotExistException::class);
-        $mergeable = $prophet->prophesize(Mergeable::class);
-        $mergeable->retrieve()->willReturn(['bar']);
 
-        $record = new Record($mergeStrategy->reveal(), $record->reveal(), $mergeable->reveal());
+        $field1 = $prophet->prophesize(RecordField::class);
+        $field1->name()->willReturn('foo');
+        $field1->value()->willReturn('bar');
+
+        $field2 = $prophet->prophesize(RecordField::class);
+        $field2->name()->willReturn('bar');
+        $field2->value()->willReturn('baz');
+
+        $mergeStrategy = $prophet->prophesize(MergeStrategy::class);
+
+        $previousRecord = $prophet->prophesize(Records::class);
+        $previousRecord->retrieve()->willReturn(['foo' => $field1->reveal()]);
+        $previousRecord->field($field2->reveal())->willThrow(PropertyDoesNotExistException::class);
+
+        $mergeable = $prophet->prophesize(Mergeable::class);
+        $mergeable->retrieve()->willReturn(['bar' => $field2->reveal()]);
+
+        $record = new Record($mergeStrategy->reveal(), $previousRecord->reveal());
+        $record->merge($mergeable->reveal());
 
         $this->assertEquals(
-            ['bar'],
+            [
+                'foo' => $field1->reveal(),
+                'bar' => $field2->reveal(),
+            ],
             $record->retrieve()
         );
     }
 
-    public function testItMergesProperties()
+    public function testItsIndividualPropertiesCanBeAccessedBeforeMerge()
     {
         $prophet = new Prophet;
+
+        $field1 = $prophet->prophesize(RecordField::class);
+        $field1->name()->willReturn('foo');
+        $field1->value()->willReturn('bar');
+
+        $fieldName = $prophet->prophesize(RecordField::class);
+        $fieldName->name()->willReturn('foo');
+
         $mergeStrategy = $prophet->prophesize(MergeStrategy::class);
-        $record = $prophet->prophesize(Records::class);
-        $record->retrieve()->willReturn(['foo' => 'foo']);
-        $record->property('bar')->willThrow(PropertyDoesNotExistException::class);
-        $mergeable = $prophet->prophesize(Mergeable::class);
-        $mergeable->retrieve()->willReturn(['bar' => 'bar']);
 
-        $record = new Record($mergeStrategy->reveal(), $record->reveal(), $mergeable->reveal());
+        $previousRecord = $prophet->prophesize(Records::class);
+        $previousRecord->retrieve()->willReturn(['foo' => $field1->reveal()]);
 
-        $this->assertEquals(
-            ['foo' => 'foo', 'bar' => 'bar'],
-            $record->retrieve()
-        );
+        $record = new Record($mergeStrategy->reveal(), $previousRecord->reveal());
+
+        $this->assertEquals($field1->reveal(), $record->field($fieldName->reveal()));
     }
 
-    public function testItsIndividualPropertiesCanBeAccessed()
+    public function testItsIndividualPropertiesCanBeAccessedAfterMerge()
     {
         $prophet = new Prophet;
+
+        $field1 = $prophet->prophesize(RecordField::class);
+        $field1->name()->willReturn('foo');
+        $field1->value()->willReturn('bar');
+
+        $field2 = $prophet->prophesize(RecordField::class);
+        $field2->name()->willReturn('bar');
+        $field2->value()->willReturn('baz');
+
+        $fieldName = $prophet->prophesize(RecordField::class);
+        $fieldName->name()->willReturn('bar');
+
         $mergeStrategy = $prophet->prophesize(MergeStrategy::class);
-        $record = $prophet->prophesize(Records::class);
-        $record->retrieve()->willReturn(['foo' => 'foo']);
-        $record->property('bar')->willThrow(PropertyDoesNotExistException::class);
+
+        $previousRecord = $prophet->prophesize(Records::class);
+        $previousRecord->retrieve()->willReturn(['foo' => $field1->reveal()]);
+        $previousRecord->field($field2->reveal())->willThrow(PropertyDoesNotExistException::class);
+
         $mergeable = $prophet->prophesize(Mergeable::class);
-        $mergeable->retrieve()->willReturn(['bar' => 'bar']);
+        $mergeable->retrieve()->willReturn(['bar' => $field2->reveal()]);
 
-        $record = new Record($mergeStrategy->reveal(), $record->reveal(), $mergeable->reveal());
+        $record = new Record($mergeStrategy->reveal(), $previousRecord->reveal());
+        $record->merge($mergeable->reveal());
 
-        $this->assertEquals(
-            'foo',
-            $record->property('foo')
-        );
+        $this->assertEquals($field2->reveal(), $record->field($fieldName->reveal()));
     }
 
     public function testItsDefersTheMergeDetailsToTheMergeStrategy()
     {
         $prophet = new Prophet;
+
+        $field1 = $prophet->prophesize(RecordField::class);
+        $field1->name()->willReturn('foo');
+        $field1->value()->willReturn('bar');
+
+        $field2 = $prophet->prophesize(RecordField::class);
+        $field2->name()->willReturn('foo');
+        $field2->value()->willReturn('baz');
+
         $mergeStrategy = $prophet->prophesize(MergeStrategy::class);
-        $mergeStrategy->merge('bar', 'bar', 'bar')->willReturn('sheep');
-        $record = $prophet->prophesize(Records::class);
-        $record->retrieve()->willReturn(['foo' => 'foo']);
-        $record->property('bar')->willReturn('bar');
+        $mergeStrategy->merge($field1->reveal(), $field2->reveal())->willReturn($field2->reveal());
+
+        $previousRecord = $prophet->prophesize(Records::class);
+        $previousRecord->retrieve()->willReturn(['foo' => $field1->reveal()]);
+        $previousRecord->field($field2->reveal())->willReturn($field1->reveal());
+
         $mergeable = $prophet->prophesize(Mergeable::class);
-        $mergeable->retrieve()->willReturn(['bar' => 'bar']);
+        $mergeable->retrieve()->willReturn(['foo' => $field2->reveal()]);
 
-        $record = new Record($mergeStrategy->reveal(), $record->reveal(), $mergeable->reveal());
+        $record = new Record($mergeStrategy->reveal(), $previousRecord->reveal());
+        $record->merge($mergeable->reveal());
 
-        $this->assertEquals(
-            'sheep',
-            $record->property('bar')
-        );
+        $this->assertEquals(['foo' => $field2->reveal()], $record->retrieve());
+    }
+
+    public function testTheArrayKeysDoNotReallyMatterIfTheFieldsAreTheSame()
+    {
+        $prophet = new Prophet;
+
+        $field1 = $prophet->prophesize(RecordField::class);
+        $field1->name()->willReturn('foo');
+        $field1->value()->willReturn('bar');
+
+        $field2 = $prophet->prophesize(RecordField::class);
+        $field2->name()->willReturn('foo');
+        $field2->value()->willReturn('baz');
+
+        $mergeStrategy = $prophet->prophesize(MergeStrategy::class);
+        $mergeStrategy->merge($field1->reveal(), $field2->reveal())->willReturn($field2->reveal());
+
+        $previousRecord = $prophet->prophesize(Records::class);
+        $previousRecord->retrieve()->willReturn(['foo' => $field1->reveal()]);
+        $previousRecord->field($field2->reveal())->willReturn($field1->reveal());
+
+        $mergeable = $prophet->prophesize(Mergeable::class);
+        $mergeable->retrieve()->willReturn(['b' => $field2->reveal()]);
+
+        $record = new Record($mergeStrategy->reveal(), $previousRecord->reveal());
+        $record->merge($mergeable->reveal());
+
+        $this->assertEquals(['foo' => $field2->reveal()], $record->retrieve());
     }
 
     public function testItRevertsAndReturnsAnInstanceOfAPreviousRecord()
     {
         $prophet = new Prophet;
+
+        $field1 = $prophet->prophesize(RecordField::class);
+        $field1->name()->willReturn('foo');
+        $field1->value()->willReturn('bar');
+
+        $field2 = $prophet->prophesize(RecordField::class);
+        $field2->name()->willReturn('foo');
+        $field2->value()->willReturn('baz');
+
         $mergeStrategy = $prophet->prophesize(MergeStrategy::class);
-        $mergeStrategy->merge('bar', 'bar', 'bar')->willReturn('sheep');
-        $record = $prophet->prophesize(Records::class);
-        $record->retrieve()->willReturn(['foo' => 'foo']);
-        $record->property('bar')->willReturn('bar');
+        $mergeStrategy->merge($field1->reveal(), $field2->reveal())->willReturn($field2->reveal());
+
+        $previousRecord = $prophet->prophesize(Records::class);
+        $previousRecord->retrieve()->willReturn(['foo' => $field1->reveal()]);
+        $previousRecord->field($field2->reveal())->willReturn($field1->reveal());
+
         $mergeable = $prophet->prophesize(Mergeable::class);
-        $mergeable->retrieve()->willReturn(['bar' => 'bar']);
+        $mergeable->retrieve()->willReturn(['foo' => $field2->reveal()]);
 
-        $record = new Record($mergeStrategy->reveal(), $record->reveal(), $mergeable->reveal());
-        $revert = $record->revert();
+        $record = new Record($mergeStrategy->reveal(), $previousRecord->reveal());
+        $record->merge($mergeable->reveal());
+        $previous = $record->revert();
 
-        $this->assertTrue(in_array(
-            Records::class,
-            class_implements($revert)
-        ));
+        $this->assertTrue($previous instanceof Records);
     }
 
     public function testItRevertsAndReturnsThePreviousRecordWithCorrectData()
     {
         $prophet = new Prophet;
+
+        $field1 = $prophet->prophesize(RecordField::class);
+        $field1->name()->willReturn('foo');
+        $field1->value()->willReturn('bar');
+
+        $field2 = $prophet->prophesize(RecordField::class);
+        $field2->name()->willReturn('foo');
+        $field2->value()->willReturn('baz');
+
         $mergeStrategy = $prophet->prophesize(MergeStrategy::class);
-        $mergeStrategy->merge('bar', 'bar', 'bar')->willReturn('sheep');
-        $record = $prophet->prophesize(Records::class);
-        $record->retrieve()->willReturn(['foo' => 'foo']);
-        $record->property('bar')->willReturn('bar');
+        $mergeStrategy->merge($field1->reveal(), $field2->reveal())->willReturn($field2->reveal());
+
+        $previousRecord = $prophet->prophesize(Records::class);
+        $previousRecord->retrieve()->willReturn(['foo' => $field1->reveal()]);
+        $previousRecord->field($field2->reveal())->willReturn($field1->reveal());
+
         $mergeable = $prophet->prophesize(Mergeable::class);
-        $mergeable->retrieve()->willReturn(['bar' => 'bar']);
+        $mergeable->retrieve()->willReturn(['foo' => $field2->reveal()]);
 
-        $record = new Record($mergeStrategy->reveal(), $record->reveal(), $mergeable->reveal());
-        $revert = $record->revert();
+        $record = new Record($mergeStrategy->reveal(), $previousRecord->reveal());
+        $record->merge($mergeable->reveal());
+        $previous = $record->revert();
 
-        $this->assertEquals(
-            'bar',
-            $revert->property('bar')
-        );
+        $this->assertEquals($field1->reveal(), $previous->field($field2->reveal()));
     }
 }

--- a/tests/ReturnType/Type/ToArrayTest.php
+++ b/tests/ReturnType/Type/ToArrayTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use Consolidare\RecordFields\RecordField;
+use Consolidare\Record\Records;
+use Consolidare\ReturnType\ReturnType;
+use Consolidare\ReturnType\Type\ToArray;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophet;
+
+class ToArrayTest extends TestCase
+{
+    public function testItConstructs()
+    {
+        $toArray = new ToArray;
+        $this->assertTrue($toArray instanceof ToArray);
+    }
+
+    public function testItImplementsReturnTypeInterface()
+    {
+        $toArray = new ToArray;
+        $this->assertTrue(
+            in_array(
+                ReturnType::class,
+                class_implements($toArray)
+            )
+        );
+    }
+
+    public function testItConvertsToArray()
+    {
+        $prophet = new Prophet;
+
+        $field1 = $prophet->prophesize(RecordField::class);
+        $field1->value()->willReturn('a');
+        $field2 = $prophet->prophesize(RecordField::class);
+        $field2->value()->willReturn('b');
+
+        $record = $prophet->prophesize(Records::class);
+        $record->retrieve()->willReturn([
+            'field_1' => $field1->reveal(),
+            'field_2' => $field2->reveal(),
+        ]);
+
+        $toArray = new ToArray;
+        $this->assertEquals([
+            'field_1' => 'a',
+            'field_2' => 'b',
+        ], $toArray($record->reveal()));
+    }
+}

--- a/tests/ReturnType/Type/ToJsonTest.php
+++ b/tests/ReturnType/Type/ToJsonTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use Consolidare\RecordFields\RecordField;
+use Consolidare\Record\Records;
+use Consolidare\ReturnType\ReturnType;
+use Consolidare\ReturnType\Type\ToJson;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophet;
+
+class ToJsonTest extends TestCase
+{
+    public function testItConstructs()
+    {
+        $toArray = new ToJson;
+        $this->assertTrue($toArray instanceof ToJson);
+    }
+
+    public function testItImplementsReturnTypeInterface()
+    {
+        $ToJson = new ToJson;
+        $this->assertTrue(
+            in_array(
+                ReturnType::class,
+                class_implements($ToJson)
+            )
+        );
+    }
+
+    public function testItConvertsToArray()
+    {
+        $prophet = new Prophet;
+
+        $field1 = $prophet->prophesize(RecordField::class);
+        $field1->value()->willReturn('a');
+        $field2 = $prophet->prophesize(RecordField::class);
+        $field2->value()->willReturn('b');
+
+        $record = $prophet->prophesize(Records::class);
+        $record->retrieve()->willReturn([
+            'field_1' => $field1->reveal(),
+            'field_2' => $field2->reveal(),
+        ]);
+
+        $toArray = new ToJson;
+        $this->assertEquals('{"field_1":"a","field_2":"b"}', $toArray($record->reveal()));
+    }
+}


### PR DESCRIPTION
Increate the abstraction level of the code by moving all the field information into the Field objects. This means that we now return by default an array of Field objects.

So I have also fixed issue #7 by adding customisable return types. This means you can still return an array if needed.
